### PR TITLE
Add permissions/cooldown manager to api

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,7 +40,7 @@ api.permissions_manager = {
     },
     userHasPermission: function (user, pId, defaultPermLevel) { // !onblacklist && (permLevelCheck || (onwhitelist && registered))
         var p = this.getPerm(pId, defaultPermLevel);
-        return !(p.blacklist.indexOf(user.username) !== -1) && ((p.level & this.getUserPermissionLevel(user) !== 0) || ((p.whitelist.indexOf(user.username) !== -1 || user.username.toLowerCase() === "cyberponthree") && user.registered));
+        return !(p.blacklist.indexOf(user.username) !== -1) && ((p.level & this.getUserPermissionLevel(user) !== 0) || ((p.whitelist.indexOf(user.username) !== -1) && user.registered));
     },
     getUserPermissionLevel: function (userData) {
         return (!(userData.admin || userData.mod || userData.ptvadmin) * this.PERMISSION_USER) +

--- a/app.js
+++ b/app.js
@@ -515,7 +515,7 @@ process.stdin.on('readable', function () {
                 break;
             case "reconnect":
                 socket.disconnect();
-                socket.reconnect();
+                socket.connect();
                 break;
             case "help":
                 printHelp();

--- a/plugins/perm_man.pbot.js
+++ b/plugins/perm_man.pbot.js
@@ -39,51 +39,54 @@ function handleMessage(data, whisper) {
     if (data.msg.toLowerCase().startsWith("!")) {
         var pars = data.msg.split(' ');
         var cmd = pars[0].toLowerCase();
-        if (cmd === '!perm' && pars.length === 4) {
+        if (cmd === '!perm') {
             if (api.permissions_manager.userHasPermission(data, "cmd.perm") || api.permissions_manager.isOwner(data)) {
-                switch (pars[2]) {
-                    case 'add':
-                        console.log(api.permissions_manager.__permsLocalStore);
-                        api.permissions_manager.addPermissionLevel(pars[1], parsePermLevel(pars[3]));
-                        console.log(api.permissions_manager.__permsLocalStore);
-                        console.log(pars[1]);
-                        console.log(parsePermLevel(pars[3]));
-                        sendMessage("Added " + pars[3] + " to " + pars[1], whisper ? data.username : undefined);
-                        break;
-                    case 'del':
-                    case 'rem':
-                    case 'delete':
-                    case 'remove':
-                        api.permissions_manager.removePermissionLevel(pars[1], parsePermLevel(pars[3]));
-                        sendMessage("Removed " + pars[3] + " from " + pars[1], whisper ? data.username : undefined);
-                        break;
-                    case 'whitelist':
-                        pars[3].split(',').forEach(function (un) {
-                            api.permissions_manager.whitelistUser(pars[1], un);
-                        });
-                        sendMessage("Whitelisted " + pars[3] + " for " + pars[1], whisper ? data.username : undefined);
-                        break;
-                    case 'unwhitelist':
-                        pars[3].split(',').forEach(function (un) {
-                            api.permissions_manager.unwhitelistUser(pars[1], un);
-                        });
-                        sendMessage("Unwhitelisted " + pars[3] + " for " + pars[1], whisper ? data.username : undefined);
-                        break;
-                    case 'blacklist':
-                        pars[3].split(',').forEach(function (un) {
-                            api.permissions_manager.blacklistUser(pars[1], un);
-                        });
-                        sendMessage("Blacklisted " + pars[3] + " for " + pars[1], whisper ? data.username : undefined);
-                        break;
-                    case 'unblacklist':
-                        pars[3].split(',').forEach(function (un) {
-                            api.permissions_manager.unblacklistUser(pars[1], un);
-                        });
-                        sendMessage("Unblacklisted " + pars[3] + " for " + pars[1], whisper ? data.username : undefined);
-                        break;
+                if (pars.length === 4) {
+                    switch (pars[2]) {
+                        case 'add':
+                            console.log(api.permissions_manager.__permsLocalStore);
+                            api.permissions_manager.addPermissionLevel(pars[1], parsePermLevel(pars[3]));
+                            console.log(api.permissions_manager.__permsLocalStore);
+                            console.log(pars[1]);
+                            console.log(parsePermLevel(pars[3]));
+                            sendMessage("Added " + pars[3] + " to " + pars[1], whisper ? data.username : undefined);
+                            break;
+                        case 'del':
+                        case 'rem':
+                        case 'delete':
+                        case 'remove':
+                            api.permissions_manager.removePermissionLevel(pars[1], parsePermLevel(pars[3]));
+                            sendMessage("Removed " + pars[3] + " from " + pars[1], whisper ? data.username : undefined);
+                            break;
+                        case 'whitelist':
+                            pars[3].split(',').forEach(function (un) {
+                                api.permissions_manager.whitelistUser(pars[1], un);
+                            });
+                            sendMessage("Whitelisted " + pars[3] + " for " + pars[1], whisper ? data.username : undefined);
+                            break;
+                        case 'unwhitelist':
+                            pars[3].split(',').forEach(function (un) {
+                                api.permissions_manager.unwhitelistUser(pars[1], un);
+                            });
+                            sendMessage("Unwhitelisted " + pars[3] + " for " + pars[1], whisper ? data.username : undefined);
+                            break;
+                        case 'blacklist':
+                            pars[3].split(',').forEach(function (un) {
+                                api.permissions_manager.blacklistUser(pars[1], un);
+                            });
+                            sendMessage("Blacklisted " + pars[3] + " for " + pars[1], whisper ? data.username : undefined);
+                            break;
+                        case 'unblacklist':
+                            pars[3].split(',').forEach(function (un) {
+                                api.permissions_manager.unblacklistUser(pars[1], un);
+                            });
+                            sendMessage("Unblacklisted " + pars[3] + " for " + pars[1], whisper ? data.username : undefined);
+                            break;
+                    }
+                } else {
+                    sendMessage("Usage: !perm <permId> <add|del> <permLevel>  |  !perm <permId> <(un)whitelist|(un)blacklist> <username>  ", data.username);
                 }
-            }
-            else {
+            } else {
                 sendMessage("Sorry, you don't have permission to use this command.", data.username);
             }
         }

--- a/plugins/perm_man.pbot.js
+++ b/plugins/perm_man.pbot.js
@@ -1,0 +1,119 @@
+var api;
+
+function newMessage(data) {
+    handleMessage(data, false);
+}
+function newWhisper(data) {
+    handleMessage(data, true);
+}
+
+function parsePermLevel(str) {
+    lvl = 0;
+    lvls = str.split(',').filter(function (v, i, s) {
+        return s.indexOf(v) === i;
+    });
+    for (var i = 0; i < lvls.length; ++i) {
+        switch (lvls[i]) {
+            case "user":
+            case "users":
+                lvl += api.permissions_manager.PERMISSION_USER;
+                break;
+            case "mod":
+            case "mods":
+                lvl += api.permissions_manager.PERMISSION_MOD;
+                break;
+            case "admin":
+            case "admins":
+                lvl += api.permissions_manager.PERMISSION_ADMIN;
+                break;
+            case "padmin":
+            case "padmins":
+                lvl += api.permissions_manager.PERMISSION_PTVADMIN;
+                break;
+        }
+    }
+    return lvl;
+}
+
+function handleMessage(data, whisper) {
+    if (data.msg.toLowerCase().startsWith("!")) {
+        var pars = data.msg.split(' ');
+        var cmd = pars[0].toLowerCase();
+        if (cmd === '!perm' && pars.length === 4) {
+            if (api.permissions_manager.userHasPermission(data, "cmd.perm") || api.permissions_manager.isOwner(data)) {
+                switch (pars[2]) {
+                    case 'add':
+                        console.log(api.permissions_manager.__permsLocalStore);
+                        api.permissions_manager.addPermissionLevel(pars[1], parsePermLevel(pars[3]));
+                        console.log(api.permissions_manager.__permsLocalStore);
+                        console.log(pars[1]);
+                        console.log(parsePermLevel(pars[3]));
+                        sendMessage("Added " + pars[3] + " to " + pars[1], whisper ? data.username : undefined);
+                        break;
+                    case 'del':
+                    case 'rem':
+                    case 'delete':
+                    case 'remove':
+                        api.permissions_manager.removePermissionLevel(pars[1], parsePermLevel(pars[3]));
+                        sendMessage("Removed " + pars[3] + " from " + pars[1], whisper ? data.username : undefined);
+                        break;
+                    case 'whitelist':
+                        pars[3].split(',').forEach(function (un) {
+                            api.permissions_manager.whitelistUser(pars[1], un);
+                        });
+                        sendMessage("Whitelisted " + pars[3] + " for " + pars[1], whisper ? data.username : undefined);
+                        break;
+                    case 'unwhitelist':
+                        pars[3].split(',').forEach(function (un) {
+                            api.permissions_manager.unwhitelistUser(pars[1], un);
+                        });
+                        sendMessage("Unwhitelisted " + pars[3] + " for " + pars[1], whisper ? data.username : undefined);
+                        break;
+                    case 'blacklist':
+                        pars[3].split(',').forEach(function (un) {
+                            api.permissions_manager.blacklistUser(pars[1], un);
+                        });
+                        sendMessage("Blacklisted " + pars[3] + " for " + pars[1], whisper ? data.username : undefined);
+                        break;
+                    case 'unblacklist':
+                        pars[3].split(',').forEach(function (un) {
+                            api.permissions_manager.unblacklistUser(pars[1], un);
+                        });
+                        sendMessage("Unblacklisted " + pars[3] + " for " + pars[1], whisper ? data.username : undefined);
+                        break;
+                }
+            }
+            else {
+                sendMessage("Sorry, you don't have permission to use this command.", data.username);
+            }
+        }
+    }
+}
+
+function sendMessage(txt, whisperUser) {
+    if (typeof whisperUser !== 'undefined') {
+        api.Messages.whisper(whisperUser, txt);
+    } else {
+        api.Messages.send(txt);
+    }
+}
+
+module.exports = {
+    meta_inf: {
+        name: "Permissions Manager",
+        version: "1.0.0",
+        description: "Manages Permissions",
+        author: "Tschrock (CyberPon3)"
+    },
+    load: function (_api) {
+        api = _api;
+    },
+    start: function () {
+        api.Events.on("userMsg", newMessage);
+        api.Events.on("whisper", newWhisper);
+    },
+    stop: function () {
+        api.Events.removeListener("userMsg", newMessage);
+        api.Events.removeListener("whisper", newWhisper);
+    }
+}

--- a/plugins/timeout_man.pbot.js
+++ b/plugins/timeout_man.pbot.js
@@ -1,0 +1,102 @@
+var api;
+
+function newMessage(data) {
+    handleMessage(data, false);
+}
+function newWhisper(data) {
+    handleMessage(data, true);
+}
+
+function parsePermLevel(str) {
+    lvl = 0;
+    lvls = str.split(',').filter(function (v, i, s) {
+        return s.indexOf(v) === i;
+    });
+    for (var i = 0; i < lvls.length; ++i) {
+        switch (lvls[i]) {
+            case "user":
+            case "users":
+                lvl += api.permissions_manager.PERMISSION_USER;
+                break;
+            case "mod":
+            case "mods":
+                lvl += api.permissions_manager.PERMISSION_MOD;
+                break;
+            case "admin":
+            case "admins":
+                lvl += api.permissions_manager.PERMISSION_ADMIN;
+                break;
+            case "padmin":
+            case "padmins":
+                lvl += api.permissions_manager.PERMISSION_PTVADMIN;
+                break;
+        }
+    }
+    return lvl;
+}
+
+function handleMessage(data, whisper) {
+    if (data.msg.toLowerCase().startsWith("!")) {
+        var pars = data.msg.split(' ');
+        var cmd = pars[0].toLowerCase();
+
+        if (cmd === '!settimeout') {
+            if (api.permissions_manager.userHasPermission(data, "cmd.settimeout") || api.permissions_manager.isOwner(data)) {
+                if (pars.length === 3 && isInt(pars[2])) {
+                    api.timeout_manager.setTimeout(pars[1], parseInt(pars[2]));
+                    sendMessage("Set timeout " + pars[1] + " to " + pars[2], data.username);
+                } else {
+                    sendMessage("Usage: !settimeout <timeoutId> <timeoutMs>", data.username);
+                }
+            } else {
+                sendMessage("Sorry, you don't have permission to use this command.", data.username);
+            }
+        }
+        if (cmd === '!resettimeout') {
+            if (api.permissions_manager.userHasPermission(data, "cmd.resettimeout") || api.permissions_manager.isOwner(data)) {
+                if (pars.length === 2) {
+                    api.timeout_manager.clearTimeout(pars[1]);
+                    sendMessage("Cleared timeout " + pars[1], data.username);
+                } else {
+                    sendMessage("Usage: !settimeout <timeoutId>", data.username);
+                }
+            } else {
+                sendMessage("Sorry, you don't have permission to use this command.", data.username);
+            }
+        }
+    }
+}
+
+function isInt(value) {
+    return !isNaN(value) && (function (x) {
+        return (x | 0) === x;
+    })(parseFloat(value));
+}
+
+function sendMessage(txt, whisperUser) {
+    if (typeof whisperUser !== 'undefined') {
+        api.Messages.whisper(whisperUser, txt);
+    } else {
+        api.Messages.send(txt);
+    }
+}
+
+module.exports = {
+    meta_inf: {
+        name: "Timeout Manager",
+        version: "1.0.0",
+        description: "Manages Timeouts",
+        author: "Tschrock (CyberPon3)"
+    },
+    load: function (_api) {
+        api = _api;
+    },
+    start: function () {
+        api.Events.on("userMsg", newMessage);
+        api.Events.on("whisper", newWhisper);
+    },
+    stop: function () {
+        api.Events.removeListener("userMsg", newMessage);
+        api.Events.removeListener("whisper", newWhisper);
+    }
+}

--- a/plugins/timeout_man.pbot.js
+++ b/plugins/timeout_man.pbot.js
@@ -7,34 +7,6 @@ function newWhisper(data) {
     handleMessage(data, true);
 }
 
-function parsePermLevel(str) {
-    lvl = 0;
-    lvls = str.split(',').filter(function (v, i, s) {
-        return s.indexOf(v) === i;
-    });
-    for (var i = 0; i < lvls.length; ++i) {
-        switch (lvls[i]) {
-            case "user":
-            case "users":
-                lvl += api.permissions_manager.PERMISSION_USER;
-                break;
-            case "mod":
-            case "mods":
-                lvl += api.permissions_manager.PERMISSION_MOD;
-                break;
-            case "admin":
-            case "admins":
-                lvl += api.permissions_manager.PERMISSION_ADMIN;
-                break;
-            case "padmin":
-            case "padmins":
-                lvl += api.permissions_manager.PERMISSION_PTVADMIN;
-                break;
-        }
-    }
-    return lvl;
-}
-
 function handleMessage(data, whisper) {
     if (data.msg.toLowerCase().startsWith("!")) {
         var pars = data.msg.split(' ');


### PR DESCRIPTION
I've added some helper objects to the API to make managing cool-downs(timeouts), permissions, and the current user data easier as well as plugins to go with them. Also added a check to filter out duplicate chat messages as well as ignore the chat backlog that gets sent on connect.

Example of new api usage: https://github.com/Tschrock/PicartoChatBot/blob/experimental/plugins/challenge_message.pbot.js
