### PR TITLE
Add username/password auth for tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "bluebird": "^3.4.6",
     "eventemitter2": "^2.1.3",
-    "jsdom": "^9.6.0",
+    "request": "^2.0.0",
     "node-persist": "^2.0.2",
     "protobufjs": "^5.0.1",
     "require-reload": "^0.2.2",


### PR DESCRIPTION
 - Rewrote `getToken` to use `request` instead of `jsdom` and added a `cookieJar` parameter.
 - Added a `getAuthedCookieJar` function which gets a logged-in cookieJar for a username/password.
 - Added a `getAuthedToken` function that gets a logged-in chat token for a username/password.